### PR TITLE
image with ruby support

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,7 +1,7 @@
 architect:
   - h1alexbel
 docker:
-  image: l3r8y/rultor-image:1.0.3
+  image: yegor256/rultor-image:1.22.0
 merge:
   script: |
     bundle install


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Docker image used in the `.rultor.yml` file.

### Detailed summary
- The Docker image `l3r8y/rultor-image:1.0.3` is replaced with `yegor256/rultor-image:1.22.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->